### PR TITLE
fix to suppress incorrect werror in some windows sdk versions

### DIFF
--- a/Source/volograms/volograms.Build.cs
+++ b/Source/volograms/volograms.Build.cs
@@ -23,6 +23,7 @@ public class volograms : ModuleRules
     string FFMPEGPath = Path.Combine(ThirdPartyPath, "ffmpeg");
     string IncludePath = Path.Combine(FFMPEGPath, "include");
     PublicIncludePaths.Add(IncludePath);
+    PublicDefinitions.Add("_CRT_HAS_CXX17=0"); // Work-around error in Windows SDK where to werrors on ifdef __cplusplus
     System.Console.WriteLine("VOL: IncludePath = " + IncludePath);
 
     if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))


### PR DESCRIPTION
Reason for PR

* Some users were reporting build errors when loading the Volograms plugin.
* This PR provides a fix to a bug that occurs building with some, but not all, versions of the Windows SDK.
* Logs showed an incorrect error on macro `__cplusplus` where the Windows CRT gets a bit stuck in its macros. Unreal must be building with /Wall and /Werror as normally this would not be reported by the compiler, and is not normally an error that blocks building.
* `__cplusplus` is a compiler definition that is used to force C++ compilers to compile a block of C code as C. This is the case in our vol_av and vol_geom libraries (and possibly also ffmpeg).
* Relevant link to U4 forum post about the issue https://forums.unrealengine.com/t/error-c4668-__cplusplus-not-defined/439295

Changes in PR

* The build.cs file that builds the plugin has a line that suppresses the warning/error from being reported by avoiding the incorrect macro path in the windows CRT header.

Testing Done

* @valeria-volu tested it in her blocked build and it seemed to work.
* Tested on my non-blocked build to make sure it didn't break anything that was working or report any issues - it was fine.
* Have not confirmed yet if it will unstick users in the focus group forum, but will check after merging this PR.

Risk of Merging PR

* No code was changed but I'm not able to get a full coverage test across different versions of Windows SDK/unreal/VS, so worst case scenario it breaks some builds that were working before, but I think that's unlikely.
* A better solution may be to require users to update the Windows SDK, but I think this is easier to deal with if it works. 